### PR TITLE
Raise e instead of raise e.message

### DIFF
--- a/lib/octopus/proxy.rb
+++ b/lib/octopus/proxy.rb
@@ -45,7 +45,7 @@ module Octopus
           conn.verify!
           retry if (retries += 1) < 3
         else
-          raise e.message
+          raise e
         end
       end
     end
@@ -62,7 +62,7 @@ module Octopus
           conn.verify!
           retry if (retries += 1) < 3
         else
-          raise e.message
+          raise e
         end
       end
     end
@@ -80,7 +80,7 @@ module Octopus
           conn.verify!
           retry if (retries += 1) < 3
         else
-          raise e.message
+          raise e
         end
       end
     end
@@ -166,7 +166,7 @@ module Octopus
           select_connection.verify!
           retry if (retries += 1) < 3
         else
-          raise e.message
+          raise e
         end
       end
     end
@@ -267,7 +267,7 @@ module Octopus
           select_connection.verify!
           retry if (retries += 1) < 3
         else
-          raise e.message
+          raise e
         end
       end
     end


### PR DESCRIPTION
https://github.com/brianbroderick/octopus/blob/master/lib/octopus/proxy.rb#L83

this wraps an exception in `RuntimeError`, we were expecting PG::UniqueViolation wrapped by ActiveRecord::RecordNotUnique errors. Is there any way you can just `raise e` to keep the original exception class?